### PR TITLE
Copy authorized_keys of root

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -392,6 +392,11 @@ postbootstrap_configuration() {
 		rm -rf /archroot/{home,root}
 		cp -al /{home,root} /archroot/
 	fi
+	
+	# authorized_keys of root will be copied anyway
+	mkdir -p /archroot/root/.ssh/
+	chmod 700 /archroot/root/.ssh/
+	cp -p /root/.ssh/authorized_keys /archroot/root/.ssh/authorized_keys
 
 	# setup machine id
 	chroot /archroot systemd-machine-id-setup


### PR DESCRIPTION
If a droplet was created with SSH keys preloaded, there will be no root password so `ssh root@new_arch_droplet` will no work. It is better to copy `/root/.ssh/authorized_keys` file no matter user chooses to preserve home directories or not.