### PR TITLE
install: Add network header override

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -912,6 +912,11 @@ process_interface() {
 			fi
 			log "Added IPv6 address ${address}/${prefix} on ${interface}."
 		fi
+		local network_tail=/etc/systemd/network/template/dosync-${interface}.network.tail
+		if [[ -r "${network_tail}" ]]; then
+			cat ${network_tail}
+			log "Appended user specified config for ${interface}."
+		fi
 	} > /run/systemd/network/dosync-${interface}.network
 }
 


### PR DESCRIPTION
- If a network header file is found, use that for generating the
  network file.
- This functionality allows users to create a header file @
  `/etc/systemd/network/template/dosync-${interface}.network.head` to
  override the default.
- Example use case: Adding `Tunnel=name-of-tunnel` to the eth0
  interface file to signal systemd-networkd to bring up a tunnel using
  the eth0 interface.
- Resolves #16 
