### PR TITLE
always set hostname from metadata service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -975,7 +975,7 @@ setup_from_metadata_service() {
 		fi
 	fi
 	local hostname
-	if ! test -e /etc/hostname && hostname=$(curl -Ssf ${meta_base}hostname); then
+	if hostname=$(curl -Ssf ${meta_base}hostname); then
 		echo "${hostname}" > /etc/hostname
 		hostname "${hostname}"
 		log "Hostname set to ${hostname} from metadata service."


### PR DESCRIPTION
makes hostname change eg. when renaming droplets
