### PR TITLE
Added functionality for user to add base_devel during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ This script supports several flags, all of which are optional.
 * `--archlinux_mirror`  
   The Arch Linux mirror from which the bootstrap image and packages should be
   downloaded. Defaults to http://mirrors.kernel.org/archlinux
+* `--developer_package`
+  The developer package allows the user to include the archlinux development package.
+  Automatically default to none. The alternative is `base-devel`.
 * `--kernel_package`  
   The kernel package to install. Defaults to the vanilla `linux` package.
   Other options include `linux-lts` for long term support and `linux-grsec` for

--- a/install.sh
+++ b/install.sh
@@ -421,7 +421,7 @@ stage1_install() {
 	local chroot_pacman="chroot /d2a/work/archroot pacman --arch ${target_architecture}"
 	${chroot_pacman} -Sy
 	${chroot_pacman} -Su --noconfirm --needed \
-		$(${chroot_pacman} -Sgq base $(developer_package) | grep -v '^linux$') \
+		$(${chroot_pacman} -Sgq base ${developer_package} | grep -v '^linux$') \
 		${arch_packages[@]}
 
 	log "Configuring base system ..."

--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,9 @@ run_from_file() {
 # mirror from which to download archlinux packages
 archlinux_mirror="http://mirrors.kernel.org/archlinux"
 
+# install archlinux developers package
+developer_package=""
+
 # package to use as kernel (linux or linux-lts)
 kernel_package=linux
 
@@ -74,6 +77,7 @@ sector_size=512
 
 flag_variables=(
 	archlinux_mirror
+	developer_package
 	kernel_package
 	target_architecture
 	target_disklabel
@@ -417,7 +421,7 @@ stage1_install() {
 	local chroot_pacman="chroot /d2a/work/archroot pacman --arch ${target_architecture}"
 	${chroot_pacman} -Sy
 	${chroot_pacman} -Su --noconfirm --needed \
-		$(${chroot_pacman} -Sgq base | grep -v '^linux$') \
+		$(${chroot_pacman} -Sgq base $(developer_package) | grep -v '^linux$') \
 		${arch_packages[@]}
 
 	log "Configuring base system ..."


### PR DESCRIPTION
Long time user of your script, cant say how much I appreciate it!

I added the ability for the user to install base_devel package during
the installation process.  Although, thinking about it, I could change
it to a general install flag instead of the developer flag.

What do you think?