### PR TITLE
use pacman --force

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -419,7 +419,7 @@ stage1_install() {
 	log "Installing base system ..."
 	chroot /d2a/work/archroot pacman-key --init
 	chroot /d2a/work/archroot pacman-key --populate archlinux
-	local chroot_pacman="chroot /d2a/work/archroot pacman --arch ${target_architecture}"
+	local chroot_pacman="chroot /d2a/work/archroot pacman --arch ${target_architecture} --force"
 	${chroot_pacman} -Sy
 	${chroot_pacman} -Su --noconfirm --needed \
 		$(${chroot_pacman} -Sgq base | grep -v '^linux$') \


### PR DESCRIPTION
avoids install failures like:

error: failed to commit transaction (conflicting files)
ca-certificates-utils: /etc/ssl/certs/ca-certificates.crt exists in filesystem

(dunno if this a good idea in general. I just needed to do this upon my first and only use and thought I'd share.)