### PR TITLE
Zero out GRUB_TIMEOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,31 +28,31 @@ Advanced Configuration
 ----------------------
 This script supports several flags, all of which are optional.
 
-* `--archlinux_mirror`
+* `--archlinux_mirror`  
   The Arch Linux mirror from which the bootstrap image and packages should be
   downloaded. Defaults to http://mirrors.kernel.org/archlinux.
-* `--extra_packages`
+* `--extra_packages`  
   Installs any extra packages to the Arch installation (e.g. base-devel).
   Packages should be space-separated and quoted
   (e.g. `--extra_packages "git wget"`).
-* `--grub_timeout`
+* `--grub_timeout`  
   Overrides the default GRUB_TIMEOUT value of 5 seconds.
-* `--kernel_package`
+* `--kernel_package`  
   The kernel package to install. Defaults to the vanilla `linux` package.
   Other options include `linux-lts` for long term support and `linux-hardened` for
   a kernel with patches from [linux-hardened](https://github.com/thestinger/linux-hardened).
-* `--mkfs_options`
+* `--mkfs_options`  
   Extra options to pass to `mkfs`. Useful for settings bytes per inode on ext4,
   e.g. `--mkfs_options="-i 65536"`.
-* `--target_architecture`
+* `--target_architecture`  
   The architecture of the new Arch Linux installation. Defaults to the
   architecture of the original Debian image as provided by `uname -m`.
   A 64-bit Debian image may convert to either `x86_64` or `i686`.
   A 32-bit Debian image may only convert to `i686`.
-* `--target_disklabel`
+* `--target_disklabel`  
   The type of partition table to use. Defaults to `gpt` (GUID partition table
   as used by EFI). The alternative is `dos` (traditional MBR).
-* `--target_filesystem`
+* `--target_filesystem`  
   The filesystem on which the Arch Linux installation should be installed.
   Defaults to `ext4`. The alternative is `btrfs`.
 

--- a/README.md
+++ b/README.md
@@ -28,31 +28,33 @@ Advanced Configuration
 ----------------------
 This script supports several flags, all of which are optional.
 
-* `--archlinux_mirror`  
+* `--archlinux_mirror`
   The Arch Linux mirror from which the bootstrap image and packages should be
-  downloaded. Defaults to http://mirrors.kernel.org/archlinux
-* `--extra_packages`  
+  downloaded. Defaults to http://mirrors.kernel.org/archlinux.
+* `--extra_packages`
   Installs any extra packages to the Arch installation (e.g. base-devel).
   Packages should be space-separated and quoted
   (e.g. `--extra_packages "git wget"`).
-* `--kernel_package`  
+* `--grub_timeout`
+  Overrides the default GRUB_TIMEOUT value of 5 seconds.
+* `--kernel_package`
   The kernel package to install. Defaults to the vanilla `linux` package.
   Other options include `linux-lts` for long term support and `linux-hardened` for
   a kernel with patches from [linux-hardened](https://github.com/thestinger/linux-hardened).
-* `--target_architecture`  
+* `--mkfs_options`
+  Extra options to pass to `mkfs`. Useful for settings bytes per inode on ext4,
+  e.g. `--mkfs_options="-i 65536"`.
+* `--target_architecture`
   The architecture of the new Arch Linux installation. Defaults to the
   architecture of the original Debian image as provided by `uname -m`.
   A 64-bit Debian image may convert to either `x86_64` or `i686`.
   A 32-bit Debian image may only convert to `i686`.
-* `--target_disklabel`  
+* `--target_disklabel`
   The type of partition table to use. Defaults to `gpt` (GUID partition table
   as used by EFI). The alternative is `dos` (traditional MBR).
-* `--target_filesystem`  
+* `--target_filesystem`
   The filesystem on which the Arch Linux installation should be installed.
   Defaults to `ext4`. The alternative is `btrfs`.
-* `--mkfs_options`
-  Extra options to pass to `mkfs`. Useful for settings bytes per inode on ext4,
-  e.g. `--mkfs_options="-i 65536"`.
 
 How it Works
 ------------

--- a/components/base-install.sh
+++ b/components/base-install.sh
@@ -37,8 +37,14 @@ archlinux_mirror="http://mirrors.kernel.org/archlinux"
 # extra packages
 extra_packages=""
 
+# grub timeout
+grub_timeout=5
+
 # package to use as kernel (linux or linux-lts)
 kernel_package=linux
+
+# extra mkfs options
+mkfs_options=""
 
 # migrated machine architecture (x86_64/i686)
 target_architecture="$(uname -m)"
@@ -48,9 +54,6 @@ target_disklabel="gpt"
 
 # new filesystem type (ext4/btrfs)
 target_filesystem="ext4"
-
-# extra mkfs options
-mkfs_options=""
 
 # NOT EXPOSED NORMALLY: don't prompt
 continue_without_prompting=0
@@ -809,6 +812,7 @@ stage4_convert() {
 	mount -t proc proc /archroot/proc
 	mount -t sysfs sys /archroot/sys
 	mount -t devtmpfs dev /archroot/dev
+	chroot /archroot sed -i "s/GRUB_TIMEOUT=5/GRUB_TIMEOUT=${grub_timeout}/" /etc/default/grub
 	chroot /archroot grub-mkconfig -o /boot/grub/grub.cfg
 	chroot /archroot grub-install /dev/vda
 	umount /archroot/dev

--- a/components/base-install.sh
+++ b/components/base-install.sh
@@ -84,6 +84,7 @@ sector_size=512
 flag_variables=(
 	archlinux_mirror
 	extra_packages
+	grub_timeout
 	kernel_package
 	target_architecture
 	target_disklabel

--- a/install.sh
+++ b/install.sh
@@ -809,6 +809,7 @@ stage4_convert() {
 	mount -t proc proc /archroot/proc
 	mount -t sysfs sys /archroot/sys
 	mount -t devtmpfs dev /archroot/dev
+	chroot /archroot sed -i "s/GRUB_TIMEOUT=5/GRUB_TIMEOUT=0/" /etc/default/grub
 	chroot /archroot grub-mkconfig -o /boot/grub/grub.cfg
 	chroot /archroot grub-install /dev/vda
 	umount /archroot/dev

--- a/install.sh
+++ b/install.sh
@@ -37,8 +37,14 @@ archlinux_mirror="http://mirrors.kernel.org/archlinux"
 # extra packages
 extra_packages=""
 
+# grub timeout
+grub_timeout=5
+
 # package to use as kernel (linux or linux-lts)
 kernel_package=linux
+
+# extra mkfs options
+mkfs_options=""
 
 # migrated machine architecture (x86_64/i686)
 target_architecture="$(uname -m)"
@@ -48,9 +54,6 @@ target_disklabel="gpt"
 
 # new filesystem type (ext4/btrfs)
 target_filesystem="ext4"
-
-# extra mkfs options
-mkfs_options=""
 
 # NOT EXPOSED NORMALLY: don't prompt
 continue_without_prompting=0
@@ -809,7 +812,7 @@ stage4_convert() {
 	mount -t proc proc /archroot/proc
 	mount -t sysfs sys /archroot/sys
 	mount -t devtmpfs dev /archroot/dev
-	chroot /archroot sed -i "s/GRUB_TIMEOUT=5/GRUB_TIMEOUT=0/" /etc/default/grub
+	chroot /archroot sed -i "s/GRUB_TIMEOUT=5/GRUB_TIMEOUT=${grub_timeout}/" /etc/default/grub
 	chroot /archroot grub-mkconfig -o /boot/grub/grub.cfg
 	chroot /archroot grub-install /dev/vda
 	umount /archroot/dev

--- a/install.sh
+++ b/install.sh
@@ -84,6 +84,7 @@ sector_size=512
 flag_variables=(
 	archlinux_mirror
 	extra_packages
+	grub_timeout
 	kernel_package
 	target_architecture
 	target_disklabel


### PR DESCRIPTION
The default 5-second GRUB_TIMEOUT has no practical benefit, and only serves to slow down the reboot, as well as any future reboots as well.

Given that there may be potential use cases for the default timeout (in case you want to poke around in GRUB), maybe this should be added in as a parameter instead?