### PR TITLE
Added xfs support, parameter mount_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This script supports several flags, all of which are optional.
   as used by EFI). The alternative is `dos` (traditional MBR).
 * `--target_filesystem`  
   The filesystem on which the Arch Linux installation should be installed.
-  Defaults to `ext4`. The alternative is `btrfs`.
+  Defaults to `ext4`. The alternative is `btrfs` and `xfs`.
 
 How it Works
 ------------

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ This script supports several flags, all of which are optional.
 * `--mkfs_options`  
   Extra options to pass to `mkfs`. Useful for settings bytes per inode on ext4,
   e.g. `--mkfs_options="-i 65536"`.
+* `--mount_options`  
+  Extra options to pass to `mount`. Useful for settings compression algorithm on btrfs.
+  e.g. `--mount_options="compress=zstd,noatime"`.
 * `--target_architecture`  
   The architecture of the new Arch Linux installation. Defaults to the
   architecture of the original Debian image as provided by `uname -m`.

--- a/install.sh
+++ b/install.sh
@@ -72,7 +72,7 @@ target_architecture="$(uname -m)"
 # new disklabel type (gpt/dos)
 target_disklabel="gpt"
 
-# new filesystem type (ext4/btrfs)
+# new filesystem type (ext4/xfs/btrfs)
 target_filesystem="ext4"
 
 # NOT EXPOSED NORMALLY: don't prompt
@@ -227,6 +227,10 @@ validate_flags_and_augment_globals() {
 		btrfs)
 			host_packages+=(btrfs-tools)
 			arch_packages+=(btrfs-progs)
+			;;
+		xfs)
+			host_packages+=(xfsprogs)
+			arch_packages+=(xfsprogs)
 			;;
 		*)
 			fatal "Unknown filesystem type: ${target_filesystem}"

--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,9 @@ kernel_package=linux
 # extra mkfs options
 mkfs_options=""
 
+# extra mount options
+mount_options=""
+
 # migrated machine architecture (x86_64/i686)
 target_architecture="$(uname -m)"
 
@@ -110,6 +113,7 @@ flag_variables=(
 	target_disklabel
 	target_filesystem
 	mkfs_options
+        mount_options
 )
 
 host_packages=(
@@ -384,7 +388,7 @@ stage1_install() {
 	log "Mounting image ..."
 	mkdir -p /d2a/work/{doroot,archroot}
 	mount ${doroot_loop} /d2a/work/doroot
-	mount ${archroot_loop} /d2a/work/archroot
+	mount ${mount_options:+-o} "${mount_options}" ${archroot_loop} /d2a/work/archroot
 
 	log "Setting up DOROOT ..."
 	mkdir -p /d2a/work/doroot/etc/network


### PR DESCRIPTION
Hello,

I added two small feature:

* Added support for xfs filesystem.
* Added options for pass mount options (e.g. compress=zstd).

I am using [Shell Parameter Expansion](http://www.network-theory.co.uk/docs/bashref/ShellParameterExpansion.html) to resolve problem in #59.

```
${parameter:+word}
If parameter is null or unset, nothing is substituted,
otherwise the expansion of word is substituted.
```

