### PR TITLE
Encode base64 data into one line

### DIFF
--- a/tools/build_self_contained_install.sh
+++ b/tools/build_self_contained_install.sh
@@ -10,4 +10,4 @@ cd ..
 
 cat components/base-install.sh
 tar -ch -C aur PKGBUILD "${source[@]}" \
-    --format=ustar --sort=name --mtime=@0 --owner=:0 --group=:0 | gzip -9n | base64
+    --format=ustar --sort=name --mtime=@0 --owner=:0 --group=:0 | gzip -9n | base64 -w0


### PR DESCRIPTION
Since the base64 is not human-readable anyway, it should be okay to encode it into one line.