### PR TITLE
ensure /boot/grub exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -836,6 +836,7 @@ stage4_convert() {
 	mount -t sysfs sys /archroot/sys
 	mount -t devtmpfs dev /archroot/dev
 	chroot /archroot sed -i "s/GRUB_TIMEOUT=5/GRUB_TIMEOUT=${grub_timeout}/" /etc/default/grub
+	chroot /archroot mkdir -p /boot/grub
 	chroot /archroot grub-mkconfig -o /boot/grub/grub.cfg
 	chroot /archroot grub-install /dev/vda
 	umount /archroot/dev


### PR DESCRIPTION
the latest grub package removed /boot/grub from the package itself,
which was causing the script to fail

https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/grub&id=d60f7037b8122c9f3ef6b33787ed6b8d2101c706