### PR TITLE
Fix regex to allow for Debian 9.11

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -258,7 +258,7 @@ sanity_checks() {
 	[ ${EUID} -eq 0 ] || fatal "Script must be run as root."
 	[ ${UID} -eq 0 ] || fatal "Script must be run as root."
 	[ -e /dev/vda ] || fatal "Script must be run on a KVM machine."
-	[[ "$(cat /etc/debian_version)" == [89].? ]] || \
+	[[ "$(cat /etc/debian_version)" =~ ^[89].+$ ]] || \
 		fatal "This script only supports Debian 8.x/9.x."
 }
 


### PR DESCRIPTION
This was tested on a fresh debian-9-x64 image. From my manual testing on the command line this regex also still works for other 8.* and 9.* versions.

Fixes #76