### PR TITLE
Add support for Debian 10

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -258,7 +258,7 @@ sanity_checks() {
 	[ ${EUID} -eq 0 ] || fatal "Script must be run as root."
 	[ ${UID} -eq 0 ] || fatal "Script must be run as root."
 	[ -e /dev/vda ] || fatal "Script must be run on a KVM machine."
-	[[ "$(cat /etc/debian_version)" =~ ^[89].+$ ]] || \
+	[[ "$(cat /etc/debian_version)" =~ ^([89]|10).+$ ]] || \
 		fatal "This script only supports Debian 8.x/9.x."
 }
 
@@ -375,6 +375,8 @@ stage1_install() {
 
 	log "Formatting image ..."
 	local doroot_loop=$(setup_loop_device ${doroot_offset_MiB} ${doroot_size_MiB})
+	# Work around losetup errors by sleeping a bit
+	sleep 5
 	local archroot_loop=$(setup_loop_device ${archroot_offset_MiB} ${archroot_size_MiB})
 	mkfs.ext4 -L DOROOT ${doroot_loop}
 	mkfs.${target_filesystem} -L ArchRoot ${mkfs_options} ${archroot_loop}


### PR DESCRIPTION
There seem to be errors regarding the losetup calls on Debian 10 with
kernel 4.19:

losetup: /d2a/work/image: failed to set up loop device: Resource temporarily unavailable

[   94.030104] loop_set_status: loop1 () has still dirty pages (nrpages=2)

This can be worked around by issuing a simple sleep call between the two
losetup calls.

---

This is inspired by https://github.com/RPi-Distro/pi-gen/pull/449/files .
Reducing the sleep from 5 seconds to 3 seconds (and everything below) fails, 4 seconds work but let's stay at 5 to be safe. I've also tried the loop from the PR linked above but sleeping for e.g. 3 seconds after a losetup call and then issuing the same call again still fails - I've tried with 5 retries. This sleep seems to be the easiest solution.

Tested on a 5$/month droplet.