### PR TITLE
Update bootstrap tarball extension

### DIFF
--- a/components/base-install.sh
+++ b/components/base-install.sh
@@ -119,6 +119,7 @@ host_packages=(
 	haveged
 	parted
 	psmisc
+	zstd
 )
 
 arch_packages=(
@@ -404,16 +405,16 @@ stage1_install() {
 
 	log "Downloading bootstrap tarball ..."
 	set -- $(wget -qO- ${archlinux_mirror}/iso/latest/sha1sums.txt |
-		grep "archlinux-bootstrap-[^-]*-${target_architecture}.tar.gz")
+		grep "archlinux-bootstrap-[^-]*-${target_architecture}.tar.zst")
 	local expected_sha1=$1
 	local bootstrap_filename=$2
 	download_and_verify \
 		${archlinux_mirror}/iso/latest/${bootstrap_filename} \
-		/d2a/bootstrap.tar.gz \
+		/d2a/bootstrap.tar.zst \
 		${expected_sha1}
 
 	log "Extracting bootstrap tarball ..."
-	tar -xzf /d2a/bootstrap.tar.gz \
+	tar -xf /d2a/bootstrap.tar.zst \
 		--directory=/d2a/work/archroot \
 		--strip-components=1
 

--- a/install.sh
+++ b/install.sh
@@ -119,6 +119,7 @@ host_packages=(
 	haveged
 	parted
 	psmisc
+	zstd
 )
 
 arch_packages=(
@@ -407,16 +408,16 @@ stage1_install() {
 
 	log "Downloading bootstrap tarball ..."
 	set -- $(wget -qO- ${archlinux_mirror}/iso/latest/sha256sums.txt |
-		grep "archlinux-bootstrap-[^-]*-${target_architecture}.tar.gz")
+		grep "archlinux-bootstrap-[^-]*-${target_architecture}.tar.zst")
 	local expected_sha256=$1
 	local bootstrap_filename=$2
 	download_and_verify \
 		${archlinux_mirror}/iso/latest/${bootstrap_filename} \
-		/d2a/bootstrap.tar.gz \
+		/d2a/bootstrap.tar.zst \
 		${expected_sha256}
 
 	log "Extracting bootstrap tarball ..."
-	tar -xzf /d2a/bootstrap.tar.gz \
+	tar -xf /d2a/bootstrap.tar.zst \
 		--directory=/d2a/work/archroot \
 		--strip-components=1
 


### PR DESCRIPTION
Starting with the 2024.05.01 release, the Arch Linux bootstrap tarball uses zstd compression.

Related to https://gitlab.archlinux.org/archlinux/archiso/-/issues/130